### PR TITLE
Fix: time series data request exceeding limit

### DIFF
--- a/internal/metrics/bsmetric/monitor.go
+++ b/internal/metrics/bsmetric/monitor.go
@@ -221,8 +221,8 @@ func GetClusterSpace(start, end, interval uint64) ([]metricomm.SpaceTrend, error
 	results := make(chan metricomm.MetricResult, requestSize)
 	totalName := fmt.Sprintf("%s&start=%d&end=%d&step=%d", CLUSTER_LOGICAL_CAPACITY, start, end, interval)
 	usedName := fmt.Sprintf("%s&start=%d&end=%d&step=%d", CLUSTER_LOGICAL_ALLOC, start, end, interval)
-	go metricomm.QueryRangeMetric(totalName, &results)
-	go metricomm.QueryRangeMetric(usedName, &results)
+	go metricomm.QueryRangeMetric(totalName, start, end, interval, &results)
+	go metricomm.QueryRangeMetric(usedName, start, end, interval, &results)
 
 	count := 0
 	for res := range results {

--- a/internal/metrics/common/common.go
+++ b/internal/metrics/common/common.go
@@ -89,18 +89,18 @@ type FileSystemInfo struct {
 }
 
 /*
-	 prometheus http api resonse data struct
+prometheus http api resonse data struct
 
-		 {
-		   "status": "success" | "error",
-		   "data": <data>,
+{
+  "status": "success" | "error",
+  "data": <data>,
 
-		   // Only set if status is "error". The data field may still hold additional data.
-		   "errorType": "<string>",
-		   "error": "<string>"
-		 }
+  // Only set if status is "error". The data field may still hold additional data.
+  "errorType": "<string>",
+  "error": "<string>"
+}
 
-	 data struct: https://prometheus.io/docs/prometheus/latest/querying/api/#expression-query-result-formats
+data struct: https://prometheus.io/docs/prometheus/latest/querying/api/#expression-query-result-formats
 */
 type QueryResponseOfVector struct {
 	Status string `json:"status"`

--- a/internal/metrics/common/common.go
+++ b/internal/metrics/common/common.go
@@ -89,18 +89,18 @@ type FileSystemInfo struct {
 }
 
 /*
-prometheus http api resonse data struct
+	 prometheus http api resonse data struct
 
-{
-  "status": "success" | "error",
-  "data": <data>,
+		 {
+		   "status": "success" | "error",
+		   "data": <data>,
 
-  // Only set if status is "error". The data field may still hold additional data.
-  "errorType": "<string>",
-  "error": "<string>"
-}
+		   // Only set if status is "error". The data field may still hold additional data.
+		   "errorType": "<string>",
+		   "error": "<string>"
+		 }
 
-data struct: https://prometheus.io/docs/prometheus/latest/querying/api/#expression-query-result-formats
+	 data struct: https://prometheus.io/docs/prometheus/latest/querying/api/#expression-query-result-formats
 */
 type QueryResponseOfVector struct {
 	Status string `json:"status"`
@@ -400,10 +400,38 @@ func QueryInstantMetric(name string, results *chan MetricResult) {
 	}
 }
 
-func QueryRangeMetric(name string, results *chan MetricResult) {
+func MergeQueryResponseOfMatrix(matrix *QueryResponseOfMatrix, ofMatrix *QueryResponseOfMatrix) {
+	matrix.Status = ofMatrix.Status
+	matrix.Data.ResultType = ofMatrix.Data.ResultType
+	for _, v := range ofMatrix.Data.Result {
+		matrix.Data.Result = append(matrix.Data.Result, v)
+	}
+}
+
+func QueryRangeMetric(name string, start, end, interval uint64, results *chan MetricResult) {
 	var res QueryResponseOfMatrix
-	err := core.GMetricClient.GetMetricFromPrometheus(
-		RANGE_METRIC_PATH, VECTOR_METRIC_QUERY_KEY, name, &res)
+	var err error
+	if (end-start)/interval <= 11000 {
+		err = core.GMetricClient.GetMetricFromPrometheus(
+			RANGE_METRIC_PATH, VECTOR_METRIC_QUERY_KEY, name, &res)
+	} else {
+		num := ((end-start)/interval)/11000 + 1
+		for i := uint64(0); i < num; i++ {
+			var tempRes QueryResponseOfMatrix
+			seg := interval * 11000
+			intervalStart := start + i*seg
+			intervalEnd := start + (i+1)*seg
+			if intervalEnd > end {
+				intervalEnd = end
+			}
+			str := strings.Split(name,"&")[0]
+			splitName := fmt.Sprintf("%s&start=%d&end=%d&step=%d", str, intervalStart, intervalEnd, interval)
+			err = core.GMetricClient.GetMetricFromPrometheus(
+				RANGE_METRIC_PATH, VECTOR_METRIC_QUERY_KEY, splitName, &tempRes)
+			MergeQueryResponseOfMatrix(&res, &tempRes)
+		}
+	}
+
 	*results <- MetricResult{
 		Key:    name,
 		Err:    err,
@@ -416,7 +444,7 @@ func GetUtilization(name string, start, end, interval uint64) (map[string][]Rang
 	utilization := make(map[string][]RangeMetricItem)
 	requestSize := 1
 	results := make(chan MetricResult, requestSize)
-	QueryRangeMetric(metricName, &results)
+	QueryRangeMetric(metricName, start, end, interval, &results)
 	count := 0
 	for res := range results {
 		if res.Err != nil {
@@ -443,10 +471,10 @@ func GetPerformance(name string, start, end, interval uint64) ([]Performance, er
 	readIOPSName := fmt.Sprintf("%s%s&start=%d&end=%d&step=%ds", name, READ_IOPS, start, end, interval)
 	readBPSName := fmt.Sprintf("%s%s&start=%d&end=%d&step=%ds", name, READ_REAT, start, end, interval)
 
-	go QueryRangeMetric(writeIOPSName, &results)
-	go QueryRangeMetric(writeBPSName, &results)
-	go QueryRangeMetric(readIOPSName, &results)
-	go QueryRangeMetric(readBPSName, &results)
+	go QueryRangeMetric(writeIOPSName, start, end, interval, &results)
+	go QueryRangeMetric(writeBPSName, start, end, interval, &results)
+	go QueryRangeMetric(readIOPSName, start, end, interval, &results)
+	go QueryRangeMetric(readBPSName, start, end, interval, &results)
 
 	count := 0
 	for res := range results {
@@ -517,10 +545,10 @@ func GetUserPerformance(name string, start, end, interval uint64) ([]UserPerform
 	readQPSName := fmt.Sprintf("%s%s&start=%d&end=%d&step=%ds", name, READ_QPS, start, end, interval)
 	readBPSName := fmt.Sprintf("%s%s&start=%d&end=%d&step=%ds", name, READ_BPS, start, end, interval)
 
-	go QueryRangeMetric(writeQPSName, &results)
-	go QueryRangeMetric(writeBPSName, &results)
-	go QueryRangeMetric(readQPSName, &results)
-	go QueryRangeMetric(readBPSName, &results)
+	go QueryRangeMetric(writeQPSName, start, end, interval, &results)
+	go QueryRangeMetric(writeBPSName, start, end, interval, &results)
+	go QueryRangeMetric(readQPSName, start, end, interval, &results)
+	go QueryRangeMetric(readBPSName, start, end, interval, &results)
 
 	count := 0
 	for res := range results {

--- a/internal/metrics/common/disk.go
+++ b/internal/metrics/common/disk.go
@@ -69,10 +69,10 @@ func GetDiskPerformance(instance string, start, end, interval uint64) (interface
 	readBPSName := fmt.Sprintf("%s&start=%d&end=%d&step=%ds",
 		GetNodeDiskPerformanceName(NODE_DISK_READ_BYTES_TOTAL, instance, interval), start, end, interval)
 
-	go QueryRangeMetric(writeIOPSName, &results)
-	go QueryRangeMetric(writeBPSName, &results)
-	go QueryRangeMetric(readIOPSName, &results)
-	go QueryRangeMetric(readBPSName, &results)
+	go QueryRangeMetric(writeIOPSName,start,end,interval, &results)
+	go QueryRangeMetric(writeBPSName,start,end,interval, &results)
+	go QueryRangeMetric(readIOPSName,start,end,interval, &results)
+	go QueryRangeMetric(readBPSName,start,end,interval, &results)
 
 	count := 0
 	for res := range results {

--- a/internal/metrics/common/host.go
+++ b/internal/metrics/common/host.go
@@ -185,8 +185,8 @@ func GetNetWorkTraffic(instance string, start, end, interval uint64) (interface{
 	transmitName := fmt.Sprintf("%s&start=%d&end=%d&step=%ds",
 		GetNodeNetWorkReveiveName(NODE_NETWORK_TRANSMIT_BYTES_TOTAL, instance, interval), start, end, interval)
 
-	go QueryRangeMetric(receiveName, &results)
-	go QueryRangeMetric(transmitName, &results)
+	go QueryRangeMetric(receiveName,start,end,interval, &results)
+	go QueryRangeMetric(transmitName,start,end,interval, &results)
 
 	count := 0
 	for res := range results {


### PR DESCRIPTION
## Description
I implemented the logic of multiple requests in the QueryRangeMetric function of internal/metrics/common/common.go. I think it is more complicated to get the time information from the name parameter, so I need to pass in three parameters: start, end and interval. This results in many calls to this function needing to be modified, so there are more changes.   

If it feels inappropriate, I will modify the code again.

## Related issue
#3 